### PR TITLE
added color histogram to similarity.py + functionality when program crashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,6 @@ jobs:
       - name: lint with ruff
         run: |
           ruff resources/.
-      #- name: test with pytest
-        #run: |
-          #pytest -v
+      - name: test with pytest
+        run: |
+          pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,15 @@ dependencies = [
     "ruff == 0.1.7",
     "pytest==7.4.3", 
     "numpy==1.26.1",
-    "pandas==2.2.0"
+    "pandas==2.2.0",
+    "torch",
+    "torchvision",
+    "ultralytics",
+    "tqdm",
+    "Pillow",
+    "opencv-python",
+    "scikit-learn",
+    "scipy",
 ]
 
 description = "A package implementing the Image-recommender"

--- a/resources/color_vector.py
+++ b/resources/color_vector.py
@@ -27,6 +27,9 @@ def color_histogram(image, bins=256, group_size=2):
             grouped_hist.append(group_mean)
         return np.array(grouped_hist)
     
+    if image.ndim == 2:
+        image = np.stack((image,) * 3, axis=-1)
+    
     hist_r = cv2.calcHist([image], [0], None, [bins], [0, 256]).flatten()
     hist_g = cv2.calcHist([image], [1], None, [bins], [0, 256]).flatten()
     hist_b = cv2.calcHist([image], [2], None, [bins], [0, 256]).flatten()

--- a/resources/generator.py
+++ b/resources/generator.py
@@ -11,7 +11,6 @@ class ImageGenerator:
         - image_generator(): Generates images (paths) from the directory one by one.
         """
         self.directory = directory
-        self.processed_paths = set()
 
     def image_generator(self):
         for root, _, files in os.walk(self.directory):
@@ -19,14 +18,9 @@ class ImageGenerator:
                 
                 if file.lower().endswith(('png', 'jpg', 'jpeg')):
                     file_path = os.path.join(root, file)
-                    
-                    if file_path in self.processed_paths:
-                        continue
                      
                     try:
                         image = Image.open(file_path)
-                        yield image
-                        self.processed_paths.add(file_path) 
-                        
+                        yield image    
                     except Exception as e:
                         print(f"Error opening image {file_path}: {e}")

--- a/resources/metadata_reader.py
+++ b/resources/metadata_reader.py
@@ -70,6 +70,21 @@ def fetch_metadata(limit=5):
     conn.close()
     return df
 
+def get_last_entry():
+    """
+    Retrieves the last entry ID from the 'metadata' table in the SQLite database.
+    Returns the last entry ID as an integer.
+    """
+    conn = sqlite3.connect("image_metadata.db")
+    query = "SELECT id FROM metadata ORDER BY id DESC LIMIT 1"
+    df = pd.read_sql_query(query, conn)
+    try:
+        id = int(df.id.iloc[0])
+    except:
+        id = 0
+    conn.close()
+    return id
+
 
 if __name__ == "__main__":
     # Path to the directory containing the images

--- a/resources/metadata_reader.py
+++ b/resources/metadata_reader.py
@@ -80,7 +80,7 @@ def get_last_entry():
     df = pd.read_sql_query(query, conn)
     try:
         id = int(df.id.iloc[0])
-    except:
+    except Exception:
         id = 0
     conn.close()
     return id

--- a/resources/similarity.py
+++ b/resources/similarity.py
@@ -1,5 +1,7 @@
+import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity as cos_similarity
 from scipy.spatial import distance
+from resources.color_vector import color_histogram
 from resources.embedding import inception_v3
 from resources.yolo import get_yolo_classes
 
@@ -14,8 +16,8 @@ def cosine_similarity(v1, v2):
 
 
 def get_similarities(img, args):
+    histogram = color_histogram(np.array(img))
     features = inception_v3(img, args.device)
     yolo_classes = get_yolo_classes(img)
-    ### other similarities
 
-    return [features, yolo_classes]
+    return [histogram, features, yolo_classes]

--- a/test/test_similarity.py
+++ b/test/test_similarity.py
@@ -1,4 +1,4 @@
-from resources.image_similarity import *
+from resources.similarity import *
 import numpy as np
 
 v1 = np.array([0.1, 0.2, 0.4, 0.6])


### PR DESCRIPTION
The color histogram of each image is now also saved in the pkl file and grayscale images are now also processed.

I also reverted your changes regarding skipping already saved images after a crash. In order for this to work as you planned with a set in the generator, we would have to save the corresponding paths in an external file. Otherwise the content of this set would be lost after a crash.
Therefore, I have now solved it in the `main.run` by first looking at what the last saved ids in the database and the pkl file are and then starting the actual loop from there.

I hope you are fine with the changes otherwise or if you have any questions please let me know :)


EDIT:
I also activated testing in our workflow.